### PR TITLE
Normalize line-endings for all text files

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,5 @@
+# normalize line-endings for all text files
+* text=auto
+
+# ensure bash scripts checkout with LF line-endings
 /jsc eol=lf


### PR DESCRIPTION
This change updates the `.gitattributes` file to ensure that all
detected text files have normalized line-endings when committed to the
object repository.
