### PR TITLE
typings: Update to latest `estree` type definitions

### DIFF
--- a/src/compiler.ts
+++ b/src/compiler.ts
@@ -1972,7 +1972,7 @@ function compileSource (
     function compileLiteral (scope: Scope, literal: ESTree.Literal, need: boolean): hir.RValue
     {
         if (literal.regex)
-            return compileRegexLiteral(scope, <ESTree.RegexLiteral>literal, need);
+            return compileRegexLiteral(scope, <ESTree.RegExpLiteral>literal, need);
 
         if (need) {
             return hir.wrapImmediate(literal.value);
@@ -1981,7 +1981,7 @@ function compileSource (
         }
     }
 
-    function compileRegexLiteral (scope: Scope, regexLit: ESTree.RegexLiteral, need: boolean): hir.RValue
+    function compileRegexLiteral (scope: Scope, regexLit: ESTree.RegExpLiteral, need: boolean): hir.RValue
     {
         if (!m_specVars.regExp) {
             error(location(regexLit), "RegExp not initialized yet");

--- a/tsd.json
+++ b/tsd.json
@@ -12,7 +12,7 @@
       "commit": "8c7444882a2bc2ab87387f8f736a7d97e89b9c90"
     },
     "estree/estree.d.ts": {
-      "commit": "8c7444882a2bc2ab87387f8f736a7d97e89b9c90"
+      "commit": "3fc1377ce29dd9670975cb68615edf1b819fc4a5"
     }
   }
 }

--- a/typings/estree/estree.d.ts
+++ b/typings/estree/estree.d.ts
@@ -22,7 +22,7 @@ declare module ESTree {
   }
 
   interface Program extends Node {
-    body: Array<Statement>;
+    body: Array<Statement | ModuleDeclaration>;
     sourceType: string;
   }
 
@@ -72,7 +72,6 @@ declare module ESTree {
   interface SwitchStatement extends Statement {
     discriminant: Expression;
     cases: Array<SwitchCase>;
-    lexical: boolean;
   }
 
   interface ReturnStatement extends Statement {
@@ -227,7 +226,7 @@ declare module ESTree {
     value?: string | boolean | number | RegExp;
   }
 
-  interface RegexLiteral extends Literal {
+  interface RegExpLiteral extends Literal {
     regex: {
       pattern: string;
       flags: string;
@@ -258,6 +257,7 @@ declare module ESTree {
 
   interface YieldExpression extends Expression {
     argument?: Expression;
+    delegate: boolean;
   }
 
   interface TemplateLiteral extends Expression {
@@ -274,7 +274,7 @@ declare module ESTree {
     tail: boolean;
     value: {
       cooked: string;
-      value: string;
+      raw: string;
     };
   }
 
@@ -312,7 +312,7 @@ declare module ESTree {
   }
 
   interface MethodDefinition extends Node {
-    key: Identifier;
+    key: Expression;
     value: FunctionExpression;
     kind: string;
     computed: boolean;
@@ -330,40 +330,40 @@ declare module ESTree {
     property: Identifier;
   }
 
-  interface ImportDeclaration extends Node {
+  interface ModuleDeclaration extends Node {}
+
+  interface ModuleSpecifier extends Node {
+    local: Identifier;
+  }
+
+  interface ImportDeclaration extends ModuleDeclaration {
     specifiers: Array<ImportSpecifier | ImportDefaultSpecifier | ImportNamespaceSpecifier>;
     source: Literal;
   }
 
-  interface ImportSpecifier {
+  interface ImportSpecifier extends ModuleSpecifier {
     imported: Identifier;
-    local: Identifier;
   }
 
-  interface ImportDefaultSpecifier {
-    local: Identifier;
-  }
+  interface ImportDefaultSpecifier extends ModuleSpecifier {}
 
-  interface ImportNamespaceSpecifier {
-    local: Identifier;
-  }
+  interface ImportNamespaceSpecifier extends ModuleSpecifier {}
 
-  interface ExportNamedDeclaration extends Node {
+  interface ExportNamedDeclaration extends ModuleDeclaration {
     declaration?: Declaration;
     specifiers: Array<ExportSpecifier>;
     source?: Literal;
   }
 
-  interface ExportSpecifier {
+  interface ExportSpecifier extends ModuleSpecifier {
     exported: Identifier;
-    local: Identifier;
   }
 
-  interface ExportDefaultDeclaration extends Node {
+  interface ExportDefaultDeclaration extends ModuleDeclaration {
     declaration: Declaration | Expression;
   }
 
-  interface ExportAllDeclaration extends Node {
+  interface ExportAllDeclaration extends ModuleDeclaration {
     source: Literal;
   }
 }


### PR DESCRIPTION
This commit updates the `estree` type definitions to the latest
specification defined at:
https://github.com/estree/estree/blob/ec739414742e0a4495030767ebfaaf69fc22fdfe/spec.md

Source was updated appropriately to be aligned with latest definition
updates.

Note that I still left the `CatchClause.guard` typing override intact.
