### PR TITLE
Update `license` to be SPDX compatible in `package.json`

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "url": "https://github.com/tmikov/jscomp.git"
   },
   "author": "Tzvetan Mikov <tmikov@gmail.com>",
-  "license": "Apache 2.0",
+  "license": "Apache-2.0",
   "bugs": {
     "url": "https://github.com/tmikov/jscomp/issues"
   },


### PR DESCRIPTION
This prevents `npm` from complaining that the value is not a valid SPDX
license expression.
