### PR TITLE
deps: Add `typescript` as an explicit dev dependency

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,6 @@
-TSC=tsc
+NPM_BIN:=$(shell npm bin)
+
+TSC=$(NPM_BIN)/tsc
 TSFLAGS=--module commonjs --target ES5 --sourceMap --noImplicitAny --noEmitOnError
 
 JOBS?=2

--- a/README.adoc
+++ b/README.adoc
@@ -29,11 +29,11 @@ To build JSC You need:
 * Node.js v0.12
 * a C++11 compiler (Apple Clang or gcc-4.9 both work)
 * CMake version at least 2.8
-* TypeScript version at least 1.5.3
 * Clone the repository
 * From the root of the repository, build the runtime:
 
 ----
+npm install
 make runtime
 ----
 

--- a/package.json
+++ b/package.json
@@ -16,5 +16,7 @@
     "url": "https://github.com/tmikov/jscomp/issues"
   },
   "homepage": "https://github.com/tmikov/jscomp",
-  "devDependencies": {}
+  "devDependencies": {
+    "typescript": "^1.6.2"
+  }
 }


### PR DESCRIPTION
This ensures that the supported version of `typescript` is scoped with
the project to avoid incompatbilities with `typescript` installed
globally.
