### PR TITLE
Update type definitions

### DIFF
--- a/tsd.json
+++ b/tsd.json
@@ -6,13 +6,13 @@
   "bundle": "typings/tsd.d.ts",
   "installed": {
     "node/node.d.ts": {
-      "commit": "3fc1377ce29dd9670975cb68615edf1b819fc4a5"
+      "commit": "35989a3ab4834b8e8b2b56788f1d4fc46a25dc8d"
     },
     "acorn/acorn.d.ts": {
       "commit": "8c7444882a2bc2ab87387f8f736a7d97e89b9c90"
     },
     "estree/estree.d.ts": {
-      "commit": "3fc1377ce29dd9670975cb68615edf1b819fc4a5"
+      "commit": "35989a3ab4834b8e8b2b56788f1d4fc46a25dc8d"
     }
   }
 }

--- a/tsd.json
+++ b/tsd.json
@@ -9,7 +9,7 @@
       "commit": "35989a3ab4834b8e8b2b56788f1d4fc46a25dc8d"
     },
     "acorn/acorn.d.ts": {
-      "commit": "8c7444882a2bc2ab87387f8f736a7d97e89b9c90"
+      "commit": "35989a3ab4834b8e8b2b56788f1d4fc46a25dc8d"
     },
     "estree/estree.d.ts": {
       "commit": "35989a3ab4834b8e8b2b56788f1d4fc46a25dc8d"

--- a/typings/_overrides.d.ts
+++ b/typings/_overrides.d.ts
@@ -1,0 +1,5 @@
+declare module acorn {
+    interface Options {
+        strict?: boolean;
+    }
+}

--- a/typings/acorn/acorn.d.ts
+++ b/typings/acorn/acorn.d.ts
@@ -9,7 +9,7 @@ declare module acorn {
     var version: string;
     function parse(input: string, options?: Options): ESTree.Program;
     function parseExpressionAt(input: string, pos: number, options?: Options): ESTree.Expression;
-    function getLineInfo(input: string, pos: number): ESTree.Position;
+    function getLineInfo(input: string, offset: number): ESTree.Position;
     var defaultOptions: Options;
 
     interface TokenType {
@@ -43,7 +43,6 @@ declare module acorn {
     }
 
     interface Options {
-        strict?: boolean;
         ecmaVersion?: number;
         sourceType?: string;
         onInsertedSemicolon?: (lastTokEnd: number, lastTokEndLoc?: ESTree.Position) => any;

--- a/typings/node/node.d.ts
+++ b/typings/node/node.d.ts
@@ -334,6 +334,7 @@ declare module NodeJS {
         undefined: typeof undefined;
         unescape: (str: string) => string;
         gc: () => void;
+        v8debug?: any;
     }
 
     export interface Timer {
@@ -757,7 +758,7 @@ declare module "punycode" {
     export function toASCII(domain: string): string;
     export var ucs2: ucs2;
     interface ucs2 {
-        decode(string: string): string;
+        decode(string: string): number[];
         encode(codePoints: number[]): string;
     }
     export var version: any;
@@ -860,7 +861,7 @@ declare module "child_process" {
         env?: any;
         encoding?: string;
         timeout?: number;
-        maxBuffer?: string;
+        maxBuffer?: number;
         killSignal?: string;
     }, callback?: (error: Error, stdout: Buffer, stderr: Buffer) =>void ): ChildProcess;
     export function fork(modulePath: string, args?: string[], options?: {
@@ -899,7 +900,7 @@ declare module "child_process" {
         maxBuffer?: number;
         killSignal?: string;
         encoding?: string;
-    }): ChildProcess;
+    }): string | Buffer;
     export function execFileSync(command: string, args?: string[], options?: {
         cwd?: string;
         input?: string|Buffer;
@@ -911,26 +912,12 @@ declare module "child_process" {
         maxBuffer?: number;
         killSignal?: string;
         encoding?: string;
-    }): ChildProcess;
+    }): string | Buffer;
 }
 
 declare module "url" {
     export interface Url {
-        href: string;
-        protocol: string;
-        auth: string;
-        hostname: string;
-        port: string;
-        host: string;
-        pathname: string;
-        search: string;
-        query: any; // string | Object
-        slashes: boolean;
-        hash?: string;
-        path?: string;
-    }
-
-    export interface UrlOptions {
+        href?: string;
         protocol?: string;
         auth?: string;
         hostname?: string;
@@ -938,13 +925,14 @@ declare module "url" {
         host?: string;
         pathname?: string;
         search?: string;
-        query?: any;
+        query?: any; // string | Object
+        slashes?: boolean;
         hash?: string;
         path?: string;
     }
 
     export function parse(urlStr: string, parseQueryString?: boolean , slashesDenoteHost?: boolean ): Url;
-    export function format(url: UrlOptions): string;
+    export function format(url: Url): string;
     export function resolve(from: string, to: string): string;
 }
 
@@ -1020,10 +1008,10 @@ declare module "net" {
     }
     export function createServer(connectionListener?: (socket: Socket) =>void ): Server;
     export function createServer(options?: { allowHalfOpen?: boolean; }, connectionListener?: (socket: Socket) =>void ): Server;
-    export function connect(options: { allowHalfOpen?: boolean; }, connectionListener?: Function): Socket;
+    export function connect(options: { port: number, host?: string, localAddress? : string, localPort? : string, family? : number, allowHalfOpen?: boolean; }, connectionListener?: Function): Socket;
     export function connect(port: number, host?: string, connectionListener?: Function): Socket;
     export function connect(path: string, connectionListener?: Function): Socket;
-    export function createConnection(options: { allowHalfOpen?: boolean; }, connectionListener?: Function): Socket;
+    export function createConnection(options: { port: number, host?: string, localAddress? : string, localPort? : string, family? : number, allowHalfOpen?: boolean; }, connectionListener?: Function): Socket;
     export function createConnection(port: number, host?: string, connectionListener?: Function): Socket;
     export function createConnection(path: string, connectionListener?: Function): Socket;
     export function isIP(input: string): number;

--- a/typings/tsd.d.ts
+++ b/typings/tsd.d.ts
@@ -1,3 +1,4 @@
+/// <reference path="_overrides.d.ts" />
 /// <reference path="node/node.d.ts" />
 /// <reference path="acorn/acorn.d.ts" />
 /// <reference path="estree/estree.d.ts" />


### PR DESCRIPTION
This PR contains two commits.  The first is a straight-forward type definition update.  The other is updating `acorn` definitions while factoring out the project's specific overrides/enhancements to the definitions so that it doesn't conflict with updates from upstream.
